### PR TITLE
Pull-in latest changes for solard from dev

### DIFF
--- a/solard.c
+++ b/solard.c
@@ -907,6 +907,7 @@ SelectIdleMode() {
     short wantP1on = 0;
     short wantP2on = 0;
     short wantVon = 0;
+    short wantHon = 0;
     /* If furnace is cold - turn pump every 30 min on to prevent freezing */
     if ((Tkotel < 3.9)&&(!CPump1)&&(SCPump1 > (6*30))) wantP1on = 1;
     /* Furnace is above 50 - at these temps always run the pump */
@@ -945,10 +946,17 @@ SelectIdleMode() {
     if (solard_cfg.keep_pump1_on) wantP1on = 1;
     /* If solar is too hot - do not damage other equipment with the hot water */
     if (Tkolektor > 85) wantP2on = 0;
+    /* Between 01:00 and (NEstop-1) allow use of electrical heater so that boiler
+    lower end reaches wanted_T + 4 - this should do some savings later on... */
+    if ( (current_timer_hour >= 1) && (current_timer_hour <= (NEstop-1)) ) {
+        if (TboilerLow < ((float)solard_cfg.wanted_T+4))
+           wantHon = 1;
+    }
 
     if ( wantP1on ) ModeSelected |= 1;
     if ( wantP2on ) ModeSelected |= 2;
     if ( wantVon )  ModeSelected |= 4;
+    if ( wantHon )  ModeSelected |= 8;
     return ModeSelected;
 }
 

--- a/solard.c
+++ b/solard.c
@@ -911,7 +911,9 @@ SelectIdleMode() {
     float nightEnergyTemp = 0;
 
     /* If furnace is cold - turn pump every 30 min on to prevent freezing */
-    if ((Tkotel < 3.9)&&(!CPump1)&&(SCPump1 > (6*30))) wantP1on = 1;
+    if ((Tkotel < 2.9)&&(!CPump1)&&(SCPump1 > (6*30))) wantP1on = 1;
+    /* If ECT is cold - turn pump every 30 min on to prevent freezing */
+    if ((Tkolektor < 2.9)&&(!CPump2)&&(SCPump2 > (6*30))) wantP2on = 1;
     /* Furnace is above 50 - at these temps always run the pump */
     if (Tkotel > 50) wantP1on = 1;
     /* Furnace is above 45 and rising - turn pump on */

--- a/solard.c
+++ b/solard.c
@@ -47,7 +47,7 @@
     day_to_reset_Pcounters=7
 */
 
-#define SOLARDVERSION    "3.7-rc3 2015-11-18"
+#define SOLARDVERSION    "3.7-rc4 2015-11-27"
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/solard.c
+++ b/solard.c
@@ -634,6 +634,7 @@ signal_handler(int sig)
         break;
         case SIGTERM:
         log_message(LOG_FILE, " INFO: Terminate signal caught. Stopping.");
+        WritePersistentPower();
         if ( ! DisableGPIOpins() ) {
             log_message(LOG_FILE, " WARNING: Errors disabling GPIO! Quitting anyway.");
             exit(4);

--- a/solard.c
+++ b/solard.c
@@ -949,13 +949,13 @@ SelectIdleMode() {
     /* If solar is too hot - do not damage other equipment with the hot water */
     if (Tkolektor > 85) wantP2on = 0;
     /* In the last 2 hours of night energy tariff heat up boiler until the lower sensor
-    reads 10 C on top of desired temp or 60 C, so that less day energy gets used */
-    if ( (current_timer_hour >= (NEstop-2)) && (current_timer_hour <= NEstop) ) {
-        if (solard_cfg.wanted_T > 49) { 
+    reads 12 C on top of desired temp or 60 C, so that less day energy gets used */
+    if ( (current_timer_hour >= (NEstop-1)) && (current_timer_hour <= NEstop) ) {
+        if (solard_cfg.wanted_T > 47) { 
             nightEnergyTemp=60.0;
         } 
         else { 
-            nightEnergyTemp = ((float)solard_cfg.wanted_T+10);
+            nightEnergyTemp = ((float)solard_cfg.wanted_T + 12);
         }
         if (TboilerLow < nightEnergyTemp) { 
             wantHon = 1;

--- a/solard.c
+++ b/solard.c
@@ -47,7 +47,7 @@
     day_to_reset_Pcounters=7
 */
 
-#define SOLARDVERSION    "3.6 2015-11-08"
+#define SOLARDVERSION    "3.7-rc1 2015-11-14"
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/solard.c
+++ b/solard.c
@@ -47,7 +47,7 @@
     day_to_reset_Pcounters=7
 */
 
-#define SOLARDVERSION    "3.7-rc1 2015-11-14"
+#define SOLARDVERSION    "3.7-rc2 2015-11-15"
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/solard.c
+++ b/solard.c
@@ -47,7 +47,7 @@
     day_to_reset_Pcounters=7
 */
 
-#define SOLARDVERSION    "3.7-rc2 2015-11-15"
+#define SOLARDVERSION    "3.7-rc3 2015-11-18"
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/solard.c
+++ b/solard.c
@@ -782,8 +782,8 @@ ReadExternalPower() {
 /* Return non-zero value on critical condition found based on current data in sensors[] */
 short
 CriticalTempsFound() {
-    if (Tkotel > 72) return 1;
-    if (TboilerHigh > 72) return 3;
+    if (Tkotel > 66) return 1;
+    if (TboilerHigh > 62) return 2;
     return 0;
 }
 


### PR DESCRIPTION
Pull-in the latest changes for solard from dev:
all little quality touches - enable electrical energy saving mode (if allowed), prevent system freezes, furnace critical temp is now 66 C, which should be all right for normal use, considering 66 C on the furnace exit pipe means maybe 10-20 C more at the furnace core itself. And now solard writes down its electrical power use on exit, meaning we lose almost no data between restarts.

Cheers!
